### PR TITLE
Fix bug Engineering requiref for Mining and RoadBuilding

### DIFF
--- a/src/ts/rules/advanced.json
+++ b/src/ts/rules/advanced.json
@@ -125,7 +125,7 @@
                 "de": "Straßenbau"
             },
             "costNominal": 140,
-            "prereq": 6,
+            "prereq": "Engineering",
             "attributes": {
                 "en": "Allow movement through two areas. The first area may not contain units belonging to another nation, barbarians, or a pirate city",
                 "de": "Erlaubt Bewegung um zwei Felder. Das erste Feld darf keine Einheiten anderer Nationen, Barbaren oder eine Piratenstadt enthalten"
@@ -141,7 +141,6 @@
                 "Metalworking": 10,
                 "Agriculture": 10,
                 "Mining": 10,
-                "Engineering": 10,
                 "Democracy": 10,
                 "Monotheism": 10
             }
@@ -152,7 +151,7 @@
                 "de": "Bergbau"
             },
             "costNominal": 180,
-            "prereq": 6,
+            "prereq": "Engineering",
             "attributes": {
                 "en": "Increases the value of a set consisting of any one of iron, silver, bronze, gems or gold",
                 "de": "Erhöht den Wert eines Satzes mit Eisen, Silber, Bronze, Juwelen oder Gold"
@@ -169,7 +168,6 @@
                 "Metalworking": 10,
                 "Agriculture": 10,
                 "RoadBuilding": 10,
-                "Engineering": 10,
                 "Democracy": 10,
                 "Monotheism": 10
             }


### PR DESCRIPTION
Line 128, 155
	From "prereq": 6, To "prereq": "Engineering",

Line 144, 171:
	Remove "Engineering": 10,

Lines 144 and 171 ("Engineering": 10,) have been removed since the card "Engineering" is a necessary requirement for purchasing the "Mining" and "RoadBuild" cards. Therefore, it's not possible for these two cards to provide credit for the purchase of the "Engineering" card, which must already be owned.

